### PR TITLE
Fix Hash Equals

### DIFF
--- a/src/main/java/com/radixdlt/SecurityCritical.java
+++ b/src/main/java/com/radixdlt/SecurityCritical.java
@@ -1,0 +1,14 @@
+package com.radixdlt;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to be used for classes which require additional scrutiny
+ * in code review. These classes will be mostly low level classes whose
+ * correctness is critical for security.
+ */
+@Target(ElementType.TYPE)
+public @interface SecurityCritical {
+
+}

--- a/src/main/java/com/radixdlt/crypto/Hash.java
+++ b/src/main/java/com/radixdlt/crypto/Hash.java
@@ -140,7 +140,7 @@ public final class Hash implements Comparable<Hash> {
 
 		this.data = new byte[BYTES];
 		System.arraycopy(alreadyHashedData, offset, this.data, 0, BYTES);
-		this.hashCodeCached = Arrays.hashCode(this.data);
+		this.hashCodeCached = calculateHashCode();
 	}
 
 
@@ -161,7 +161,12 @@ public final class Hash implements Comparable<Hash> {
 		}
 
 		this.data = Bytes.fromHexString(alreadyHashedDataAsHexString);
-		this.hashCodeCached = Arrays.hashCode(this.data);
+		this.hashCodeCached = calculateHashCode();
+	}
+
+	// Required for EqualsVerifier.withCachedHashCode
+	private int calculateHashCode() {
+		return Arrays.hashCode(this.data);
 	}
 
 	/**

--- a/src/main/java/com/radixdlt/crypto/Hash.java
+++ b/src/main/java/com/radixdlt/crypto/Hash.java
@@ -220,6 +220,7 @@ public final class Hash implements Comparable<Hash> {
 
 		if (o instanceof Hash) {
 			Hash other = (Hash) o;
+			 // Need to do full byte area comparison otherwise, susceptible to birthday attack
 			return Arrays.equals(this.data, other.data);
 		}
 

--- a/src/main/java/com/radixdlt/crypto/Hash.java
+++ b/src/main/java/com/radixdlt/crypto/Hash.java
@@ -100,10 +100,9 @@ public final class Hash implements Comparable<Hash> {
 	}
 
 
-	private final byte[] 	data;
-	private Supplier<EUID>	idCached = Suppliers.memoize(this::computeId);
-
-	private final int hashCodeCached;
+	private final byte[] data;
+	private final transient Supplier<EUID> idCached = Suppliers.memoize(this::computeId);
+	private final transient int hashCodeCached;
 
 	/**
 	 * This does NOT perform any hashing, the byte array passed should be already hashed.
@@ -216,9 +215,7 @@ public final class Hash implements Comparable<Hash> {
 
 		if (o instanceof Hash) {
 			Hash other = (Hash) o;
-
-			// `hashCode()` uses `this.hashCodeCached`, which in turn is derived from `this.data`.
-			return this.hashCode() == other.hashCode();
+			return Arrays.equals(this.data, other.data);
 		}
 
 		return false;

--- a/src/main/java/com/radixdlt/crypto/Hash.java
+++ b/src/main/java/com/radixdlt/crypto/Hash.java
@@ -19,6 +19,7 @@ package com.radixdlt.crypto;
 
 import com.google.common.base.Suppliers;
 import com.google.common.primitives.UnsignedBytes;
+import com.radixdlt.SecurityCritical;
 import com.radixdlt.identifiers.EUID;
 import com.radixdlt.utils.Bytes;
 import java.security.SecureRandom;
@@ -27,8 +28,8 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+@SecurityCritical
 public final class Hash implements Comparable<Hash> {
-
 	private static final Comparator<byte[]> COMPARATOR = UnsignedBytes.lexicographicalComparator();
 	private static final SecureRandom secureRandom = new SecureRandom();
 	private static HashHandler hasher = new SHAHashHandler();

--- a/src/test/java/com/radixdlt/crypto/HashTest.java
+++ b/src/test/java/com/radixdlt/crypto/HashTest.java
@@ -48,9 +48,9 @@ public class HashTest {
 	@Test
 	public void equalsContract() {
 		EqualsVerifier.forClass(Hash.class)
-				.withIgnoredFields("data") // other field(s) dependent on `data` is used
-				.withIgnoredFields("idCached") // `idCached` is derived from other field(s) in use.
-				.verify();
+			.withCachedHashCode("hashCodeCached", "calculateHashCode", Hash.random())
+			.withIgnoredFields("idCached") // `idCached` is derived from other field(s) in use.
+			.verify();
 	}
 
 	@Test

--- a/src/test/java/com/radixdlt/crypto/HashTest.java
+++ b/src/test/java/com/radixdlt/crypto/HashTest.java
@@ -21,7 +21,11 @@ import com.google.common.base.Strings;
 import com.radixdlt.TestSetupUtils;
 import com.radixdlt.utils.Bytes;
 import com.radixdlt.utils.Longs;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -210,6 +214,18 @@ public class HashTest {
 
 		assertNotEquals(deadbeef, Hash.of(deadbeef).toByteArray());
 		assertNotEquals(deadbeef, Hash.hash256(deadbeef));
+	}
+
+	@Test
+	public void birthday_attack_test() {
+		// 32-bit hashes + 300000 hashes will have a collision 99.997% of the time.
+		// Practically high enough to catch any issues we have with hash collisions
+		final int numHashes = 300000;
+		Set<Hash> hashes = Stream.generate(Hash::random)
+			.limit(numHashes)
+			.collect(Collectors.toSet());
+
+		Assertions.assertThat(hashes).hasSize(numHashes);
 	}
 
 	private void testEncodeToHashedBytesFromString(String message, Function<byte[], byte[]> hashFunction, String expectedHashHex) {


### PR DESCRIPTION
* Removed the use of hashCode() in equals() as it doesn't guard against hash collisions very well