### PR TITLE
Feature/rpn1 399 hd wallet path

### DIFF
--- a/config/checkstyle/checkstyle_test.xml
+++ b/config/checkstyle/checkstyle_test.xml
@@ -77,9 +77,12 @@
     <!--   <property name="fileExtensions" value="java"/> -->
     <!-- </module> -->
 
+    <module name="SuppressWarningsFilter"/>
+
     <module name="TreeWalker">
         
         <module name="SuppressionCommentFilter"/>
+        <module name="SuppressWarningsHolder"/>
 
         <!-- Radix standard tab width -->
         <property name="tabWidth" value="4"/>

--- a/src/main/java/com/radixdlt/crypto/hdwallet/BIP32Path.java
+++ b/src/main/java/com/radixdlt/crypto/hdwallet/BIP32Path.java
@@ -1,0 +1,135 @@
+/*
+ *
+ *  * (C) Copyright 2020 Radix DLT Ltd
+ *  *
+ *  * Radix DLT Ltd licenses this file to you under the Apache License,
+ *  * Version 2.0 (the "License"); you may not use this file except in
+ *  * compliance with the License.  You may obtain a copy of the
+ *  * License at
+ *  *
+ *  *  http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  * either express or implied.  See the License for the specific
+ *  * language governing permissions and limitations under the License.
+ *
+ */
+
+package com.radixdlt.crypto.hdwallet;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.CharMatcher;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+final class BIP32Path implements HDPath {
+
+
+	/**
+	 * "m/" marks inclusion of private key, whereas "M/" (capital M) marks public key only.
+	 */
+	public static final char BIP32_PRIVATE_KEY_BIP44_PREFIX_CHAR = 'm';
+	public static final char BIP32_PUBLIC_KEY_ONLY_BIP44_PREFIX_CHAR = 'M';
+
+
+	public static final char BIP32_PATH_DELIMITER = '/';
+	public static final String BIP32_PRIVATE_KEY_BIP44_PREFIX = BIP32_PRIVATE_KEY_BIP44_PREFIX_CHAR + String.valueOf(BIP32_PATH_DELIMITER);
+	public static final char BIP32_HARDENED_PATH_STANDARD_MARKER = '\'';
+
+	public static final String BIP39_MNEMONIC_NO_PASSPHRASE = "";
+
+	private static final long hardenedOffset = 2147483648L;
+
+	private final String path;
+	private final boolean isHardened;
+	private final int depth;
+	private final long index;
+
+	BIP32Path(String path) throws HDPathException {
+
+		path = path.replace(" ", "");
+
+		CharMatcher matcher = CharMatcher.inRange('0', '9')
+				.or(CharMatcher.is(BIP32_PRIVATE_KEY_BIP44_PREFIX_CHAR))
+				.or(CharMatcher.is(BIP32_PUBLIC_KEY_ONLY_BIP44_PREFIX_CHAR))
+				.or(CharMatcher.is(BIP32_PATH_DELIMITER))
+				;
+
+		if (!matcher.matchesAnyOf(path)) {
+			throw HDPathException.invalidString;
+		}
+
+		this.path = path;
+		String[] pathComponents = path.split(String.valueOf(BIP32_PATH_DELIMITER));
+		this.depth = pathComponents.length - 1;
+
+		this.isHardened = path.endsWith(String.valueOf(BIP32_HARDENED_PATH_STANDARD_MARKER));
+		String lastComponent = pathComponents[depth];
+		if (isHardened) {
+			lastComponent = lastComponent.replace(String.valueOf(BIP32_HARDENED_PATH_STANDARD_MARKER), "");
+		}
+		long indexNonHardened = Long.parseUnsignedLong(lastComponent);
+		this.index = isHardened ? (indexNonHardened + hardenedOffset) : indexNonHardened;
+	}
+
+	public String toString() {
+		return path;
+	}
+
+	public boolean isHardened() {
+		return isHardened;
+	}
+
+	public int depth() {
+		return depth;
+	}
+
+	public long index() {
+		return index;
+	}
+
+	public HDPath next() {
+		try {
+			return new BIP32Path(pathOfNextKey());
+		} catch (HDPathException e) {
+			throw new IllegalArgumentException("Failed to construct next HDPath " + e);
+		}
+	}
+
+	private String pathOfNextKey() {
+		return pathOfKeySubsequentToPath(this);
+	}
+
+	/** Returns the `index` without the hardening bit set  */
+	private int num() {
+		if (!isHardened) {
+			return (int) index;
+		}
+		return (int) (index - hardenedOffset);
+	}
+
+	@VisibleForTesting
+	static String pathOfKeySubsequentToPath(BIP32Path path) {
+		int currentIndex = path.num();
+		if (currentIndex == Integer.MAX_VALUE) {
+			throw new IllegalStateException("Already at max index");
+		}
+
+		ArrayList<String> pathComponents = new ArrayList<>(Arrays.asList(path.path.split(String.valueOf(BIP32_PATH_DELIMITER))).subList(0, path.depth));
+		pathComponents.add(String.format("%d%s", currentIndex + 1, path.isHardened ? BIP32_HARDENED_PATH_STANDARD_MARKER : ""));
+		return String.join(String.valueOf(BIP32_PATH_DELIMITER), pathComponents);
+	}
+
+	@VisibleForTesting
+	static String pathOfKeySubsequentToPath(String path) {
+		try {
+			BIP32Path bip32Path = new BIP32Path(path);
+			return pathOfKeySubsequentToPath(bip32Path);
+		} catch (HDPathException e) {
+			throw new IllegalArgumentException("Failed to construct HDPath " + e);
+		}
+	}
+}

--- a/src/main/java/com/radixdlt/crypto/hdwallet/BitcoinJBIP32Path.java
+++ b/src/main/java/com/radixdlt/crypto/hdwallet/BitcoinJBIP32Path.java
@@ -1,0 +1,119 @@
+/*
+ *
+ *  * (C) Copyright 2020 Radix DLT Ltd
+ *  *
+ *  * Radix DLT Ltd licenses this file to you under the Apache License,
+ *  * Version 2.0 (the "License"); you may not use this file except in
+ *  * compliance with the License.  You may obtain a copy of the
+ *  * License at
+ *  *
+ *  *  http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  * either express or implied.  See the License for the specific
+ *  * language governing permissions and limitations under the License.
+ *
+ */
+
+package com.radixdlt.crypto.hdwallet;
+
+import org.bitcoinj.crypto.ChildNumber;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * A BIP32 path wrapping underlying implementation using BitcoinJ.
+ */
+class BitcoinJBIP32Path implements HDPath {
+
+	private static final String BIP32_HARDENED_MARKER_BITCOINJ = "H";
+
+	private static final long hardenedOffset = 2147483648L;
+
+
+	private final org.bitcoinj.crypto.HDPath path;
+
+	private BitcoinJBIP32Path(org.bitcoinj.crypto.HDPath path) {
+		this.path = path;
+	}
+
+	static BitcoinJBIP32Path fromPath(HDPath path) {
+		try {
+			return fromString(path.toString());
+		} catch (HDPathException e) {
+			throw new IllegalStateException("String representation of any path should be correct.", e);
+		}
+	}
+
+	static BitcoinJBIP32Path fromString(String path) throws HDPathException {
+		if (!HDPath.validateBIP32Path(path)) {
+			throw HDPathException.invalidString;
+		}
+		String stringPath = path.replace(BIP32_HARDENED_MARKER_STANDARD, BIP32_HARDENED_MARKER_BITCOINJ);
+		return new BitcoinJBIP32Path(org.bitcoinj.crypto.HDPath.parsePath(stringPath));
+	}
+
+	private int indexOfLastComponent() {
+		return depth() - 1;
+	}
+
+	private ChildNumber lastComponent() {
+		return path.get(indexOfLastComponent());
+	}
+
+	List<ChildNumber> componentsUpTo(int index) {
+		return IntStream.range(0, index).mapToObj(path::get).collect(Collectors.toList());
+	}
+
+	List<ChildNumber> components() {
+		return componentsUpTo(depth());
+	}
+
+	@Override
+	public boolean isHardened() {
+		return lastComponent().isHardened();
+	}
+
+	@Override
+	public boolean hasPrivateKey() {
+		return path.hasPrivateKey();
+	}
+
+	@Override
+	public String toString() {
+		return path.toString().replace(BIP32_HARDENED_MARKER_BITCOINJ, BIP32_HARDENED_MARKER_STANDARD);
+	}
+
+	@Override
+	public int depth() {
+		return path.size();
+	}
+
+	@Override
+	public long index() {
+		long index = (long) lastComponent().num();
+		if (!isHardened()) {
+			return index;
+		}
+		index += hardenedOffset;
+		return index;
+	}
+
+	@Override
+	public HDPath next() {
+		ArrayList<ChildNumber> nextPathComponents = new ArrayList<>(pathListFromBIP32Path(this, indexOfLastComponent()));
+		nextPathComponents.add(new ChildNumber(lastComponent().num() + 1, lastComponent().isHardened()));
+		org.bitcoinj.crypto.HDPath nextPath = new org.bitcoinj.crypto.HDPath(this.hasPrivateKey(), nextPathComponents);
+		return new BitcoinJBIP32Path(nextPath);
+	}
+
+	private static List<ChildNumber> pathListFromBIP32Path(BitcoinJBIP32Path path, @Nullable Integer toIndex) {
+		return path.componentsUpTo(toIndex == null ? path.indexOfLastComponent() : toIndex);
+	}
+}

--- a/src/main/java/com/radixdlt/crypto/hdwallet/BitcoinJHDKeyPairDerivation.java
+++ b/src/main/java/com/radixdlt/crypto/hdwallet/BitcoinJHDKeyPairDerivation.java
@@ -74,10 +74,7 @@ public final class BitcoinJHDKeyPairDerivation implements HDKeyPairDerivation {
 	}
 
 	private static List<ChildNumber> pathListFromHDPath(HDPath path) {
-		if (!(path instanceof BIP32Path)) {
-			throw new IllegalStateException("Expected path to be instance of BIP32Path");
-		}
-		return ((BIP32Path) path).components();
+		return BitcoinJBIP32Path.fromPath(path).components();
 	}
 
 	private DeterministicKey deriveKeyForHDPath(HDPath path) {

--- a/src/main/java/com/radixdlt/crypto/hdwallet/DefaultHDPath.java
+++ b/src/main/java/com/radixdlt/crypto/hdwallet/DefaultHDPath.java
@@ -19,15 +19,12 @@
 
 package com.radixdlt.crypto.hdwallet;
 
-public interface HDKeyPairDerivation {
-	HDKeyPair deriveKeyAtPath(HDPath path);
+public final class DefaultHDPath {
+	private DefaultHDPath() {
+		throw new IllegalStateException("Can't construct.");
+	}
 
-	default HDKeyPair deriveKeyAtPath(String path) {
-		try {
-			HDPath hdPath = DefaultHDPath.of(path);
-			return deriveKeyAtPath(hdPath);
-		} catch (HDPathException e) {
-			throw new IllegalArgumentException("Failed to construct HD path " + e);
-		}
+	public static HDPath of(String path) throws HDPathException {
+		return new BIP32Path(path);
 	}
 }

--- a/src/main/java/com/radixdlt/crypto/hdwallet/DefaultHDPath.java
+++ b/src/main/java/com/radixdlt/crypto/hdwallet/DefaultHDPath.java
@@ -25,6 +25,6 @@ public final class DefaultHDPath {
 	}
 
 	public static HDPath of(String path) throws HDPathException {
-		return new BIP32Path(path);
+		return BIP32Path.fromString(path);
 	}
 }

--- a/src/main/java/com/radixdlt/crypto/hdwallet/HDKeyPair.java
+++ b/src/main/java/com/radixdlt/crypto/hdwallet/HDKeyPair.java
@@ -20,36 +20,54 @@
 package com.radixdlt.crypto.hdwallet;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.utils.Bytes;
 
-public final class HDKeyPair {
-	private final ECKeyPair ecKeyPair;
-	private final String path;
-	private final boolean isHardened;
-	private final int depth;
 
-	public HDKeyPair(ECKeyPair ecKeyPair, String path) {
+/**
+ * A key pair which has been derived using some BIP32 path.
+ */
+public final class HDKeyPair {
+
+	private final ECKeyPair ecKeyPair;
+	private final HDPath path;
+
+	public HDKeyPair(ECKeyPair ecKeyPair, HDPath path) {
 		this.ecKeyPair = ecKeyPair;
 		this.path = path;
-		this.isHardened = path.endsWith("'");
-		this.depth = path.split("/").length - 1;
+	}
+
+	public HDPath path() {
+		return path;
 	}
 
 	public ECKeyPair keyPair() {
 		return ecKeyPair;
 	}
 
-	public String path() {
-		return path;
+	public String toString() {
+		return path.toString();
 	}
 
-	public boolean isHardened() {
-		return isHardened;
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		HDKeyPair hdKeyPair = (HDKeyPair) o;
+		boolean pathEquals = Objects.equal(path, hdKeyPair.path);
+		boolean keyPairEquals = Objects.equal(ecKeyPair, hdKeyPair.ecKeyPair);
+
+		return pathEquals && keyPairEquals;
 	}
 
-	public int depth() {
-		return depth;
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(ecKeyPair, path);
 	}
 
 	@VisibleForTesting
@@ -60,5 +78,20 @@ public final class HDKeyPair {
 	@VisibleForTesting
 	String publicKeyHex() {
 		return Bytes.toHexString(ecKeyPair.getPublicKey().getBytes());
+	}
+
+	@VisibleForTesting
+	boolean isHardened() {
+		return path.isHardened();
+	}
+
+	@VisibleForTesting
+	int depth() {
+		return path.depth();
+	}
+
+	@VisibleForTesting
+	long index() {
+		return path.index();
 	}
 }

--- a/src/main/java/com/radixdlt/crypto/hdwallet/HDPath.java
+++ b/src/main/java/com/radixdlt/crypto/hdwallet/HDPath.java
@@ -1,0 +1,59 @@
+/*
+ *
+ *  * (C) Copyright 2020 Radix DLT Ltd
+ *  *
+ *  * Radix DLT Ltd licenses this file to you under the Apache License,
+ *  * Version 2.0 (the "License"); you may not use this file except in
+ *  * compliance with the License.  You may obtain a copy of the
+ *  * License at
+ *  *
+ *  *  http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  * either express or implied.  See the License for the specific
+ *  * language governing permissions and limitations under the License.
+ *
+ */
+
+package com.radixdlt.crypto.hdwallet;
+
+public interface HDPath {
+
+	/**
+	 * The string representation of the BIP32 path, using standard notation "'" for hardened components, e.g.
+	 * "m/44'/536'/2'/1/4
+	 * @return a string representation of the BIP32 path, using standard notation "'" for hardened components, e.g.
+	 * 	 * "m/44'/536'/2'/1/4
+	 */
+	String toString();
+
+	/**
+	 * Whether the last component in the path is "hardened" or not, if the last component is not hardened, it does not mean
+	 * that potentially earlier components are not hardened as well, i.e. this only looks at the <b>last</b> component.
+	 * @return whether the last component in the path is "hardened" or not, if the last component is not hardened, it does not mean
+	 * 	 * that potentially earlier components are not hardened as well, i.e. this only looks at the <b>last</b> component.
+	 */
+	boolean isHardened();
+
+	/**
+	 * The number of components in the path, `1` is the lowest possible value, and most commonly 5 is the max depth, even though BIP32
+	 * supports a longer depth. The depth of "m/0" is 1, the depth of "m/0'/1" is 2 etc.
+	 * @return number of components in the path, `1` is the lowest possible value, and most commonly 5 is the max depth, even though BIP32
+	 * 	 * supports a longer depth. The depth of "m/0" is 1, the depth of "m/0'/1" is 2 etc.
+	 */
+	int depth();
+
+	/**
+	 * Returns the value of the last component, taking into account if it is hardened or not, i.e. the index of the path "m/0/0" is 0, but
+	 * the index of the path "m/0/0'" - which is hardened - is 2147483648 (0 | HARDENED_BITMASK) - and the index of "m/0/1'" is 2147483649
+	 * (1 | HARDENED_BITMASK).
+	 * @return the value of the last component, taking into account if it is hardened or not, i.e. the index of the path "m/0/0" is 0, but
+	 * 	 * the index of the path "m/0/0'" - which is hardened - is 2147483648 (0 | HARDENED_BITMASK) - and the index of "m/0/1'" is 2147483649
+	 * 	 * (1 | HARDENED_BITMASK).
+	 */
+	long index();
+
+	HDPath next();
+}

--- a/src/main/java/com/radixdlt/crypto/hdwallet/HDPathException.java
+++ b/src/main/java/com/radixdlt/crypto/hdwallet/HDPathException.java
@@ -19,15 +19,22 @@
 
 package com.radixdlt.crypto.hdwallet;
 
-public interface HDKeyPairDerivation {
-	HDKeyPair deriveKeyAtPath(HDPath path);
-
-	default HDKeyPair deriveKeyAtPath(String path) {
-		try {
-			HDPath hdPath = DefaultHDPath.of(path);
-			return deriveKeyAtPath(hdPath);
-		} catch (HDPathException e) {
-			throw new IllegalArgumentException("Failed to construct HD path " + e);
-		}
+public class HDPathException extends Exception {
+	public HDPathException() {
+		super();
 	}
+
+	public HDPathException(Throwable arg0) {
+		super(arg0);
+	}
+
+	public HDPathException(String arg0) {
+		super(arg0);
+	}
+
+	public HDPathException(String arg0, Throwable arg1) {
+		super(arg0, arg1);
+	}
+
+	public static final HDPathException invalidString = new HDPathException("Failed to parse provided string as HD path");
 }

--- a/src/test/java/com/radixdlt/crypto/hdwallet/BIP32PathTests.java
+++ b/src/test/java/com/radixdlt/crypto/hdwallet/BIP32PathTests.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *  * (C) Copyright 2020 Radix DLT Ltd
+ *  *
+ *  * Radix DLT Ltd licenses this file to you under the Apache License,
+ *  * Version 2.0 (the "License"); you may not use this file except in
+ *  * compliance with the License.  You may obtain a copy of the
+ *  * License at
+ *  *
+ *  *  http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  * either express or implied.  See the License for the specific
+ *  * language governing permissions and limitations under the License.
+ *
+ */
+
+package com.radixdlt.crypto.hdwallet;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+
+public class BIP32PathTests {
+
+	@Test
+	public void test_next_path() {
+		assertEquals("m/1", BIP32Path.pathOfKeySubsequentToPath("m/0"));
+		assertEquals("m/1'", BIP32Path.pathOfKeySubsequentToPath("m/0'"));
+		assertEquals("m/2'", BIP32Path.pathOfKeySubsequentToPath("m/1'"));
+		assertEquals("m/2147483647", BIP32Path.pathOfKeySubsequentToPath("m/2147483646"));
+		assertEquals("m/2147483647'", BIP32Path.pathOfKeySubsequentToPath("m/2147483646'"));
+
+		assertEquals("m/44'/1", BIP32Path.pathOfKeySubsequentToPath("m/44'/0"));
+		assertEquals("m/44'/1'", BIP32Path.pathOfKeySubsequentToPath("m/44'/0'"));
+		assertEquals("m/44'/2'", BIP32Path.pathOfKeySubsequentToPath("m/44'/1'"));
+		assertEquals("m/44'/2147483647", BIP32Path.pathOfKeySubsequentToPath("m/44'/2147483646"));
+		assertEquals("m/44'/2147483647'", BIP32Path.pathOfKeySubsequentToPath("m/44'/2147483646'"));
+	}
+
+	@Test
+	public void test_invalid_characters() {
+		assert_invalid_path("invalid");
+	}
+
+	private void assert_invalid_path(String path) {
+		assertThatThrownBy(() -> DefaultHDPath.of(path))
+				.isInstanceOf(HDPathException.class);
+	}
+}

--- a/src/test/java/com/radixdlt/crypto/hdwallet/BIP32PathTests.java
+++ b/src/test/java/com/radixdlt/crypto/hdwallet/BIP32PathTests.java
@@ -23,31 +23,110 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class BIP32PathTests {
 
 	@Test
-	public void test_next_path() {
-		assertEquals("m/1", BIP32Path.pathOfKeySubsequentToPath("m/0"));
-		assertEquals("m/1'", BIP32Path.pathOfKeySubsequentToPath("m/0'"));
-		assertEquals("m/2'", BIP32Path.pathOfKeySubsequentToPath("m/1'"));
-		assertEquals("m/2147483647", BIP32Path.pathOfKeySubsequentToPath("m/2147483646"));
-		assertEquals("m/2147483647'", BIP32Path.pathOfKeySubsequentToPath("m/2147483646'"));
+	public void test_valid_paths() {
+		assert_valid_path("");
+		assert_valid_path("/");
+		assert_valid_path("m/0");
+		assert_valid_path("m/1");
+		assert_valid_path("m/2");
+		assert_valid_path("m/0'");
+		assert_valid_path("m/1'");
+		assert_valid_path("m/2'");
+		assert_valid_path("m/2147483646");
+		assert_valid_path("m/2147483646'");
 
-		assertEquals("m/44'/1", BIP32Path.pathOfKeySubsequentToPath("m/44'/0"));
-		assertEquals("m/44'/1'", BIP32Path.pathOfKeySubsequentToPath("m/44'/0'"));
-		assertEquals("m/44'/2'", BIP32Path.pathOfKeySubsequentToPath("m/44'/1'"));
-		assertEquals("m/44'/2147483647", BIP32Path.pathOfKeySubsequentToPath("m/44'/2147483646"));
-		assertEquals("m/44'/2147483647'", BIP32Path.pathOfKeySubsequentToPath("m/44'/2147483646'"));
+		assert_valid_path("m/44'/0");
+		assert_valid_path("m/44'/0'");
+		assert_valid_path("m/44'/1");
+		assert_valid_path("m/44'/1'");
+		assert_valid_path("m/44'/2");
+		assert_valid_path("m/44'/2'");
+		assert_valid_path("m/44'/2147483646");
+		assert_valid_path("m/44'/2147483646'");
+
+		assert_valid_path("m/44'/536'/2'/1/3");
+
+		assert_valid_path("m/1/2/3/4/5/6/7/8/");
+
+		assert_valid_path("M/1/2");
+		assert_valid_path("M/1'/2'");
 	}
 
 	@Test
-	public void test_invalid_characters() {
+	public void test_creation_of_hd_path() {
+		assert_no_throw_create_hdpath_from_string("m/44'/536'/2'/1/3");
+	}
+
+
+	@Test
+	public void test_invalid_paths() {
 		assert_invalid_path("invalid");
+		assert_invalid_path("z");
+		assert_invalid_path("m/");
+		assert_invalid_path("/m");
+		assert_invalid_path(" ");
+		assert_invalid_path("/ ");
+		assert_invalid_path(" /");
+		assert_invalid_path(" m/0");
+		assert_invalid_path("m/m");
+		assert_invalid_path("m/x");
+		assert_invalid_path("m//0");
+		assert_invalid_path("m/0/1//");
+
+		assert_invalid_path("m/44'/536' / 2' / 1/3");
+	}
+
+	@Test
+	public void test_next_path() {
+		assertEquals("m/1", nextPath("m/0"));
+		assertEquals("m/1'", nextPath("m/0'"));
+		assertEquals("m/2'", nextPath("m/1'"));
+		assertEquals("m/2147483647", nextPath("m/2147483646"));
+		assertEquals("m/2147483647'", nextPath("m/2147483646'"));
+
+		assertEquals("m/44'/1", nextPath("m/44'/0"));
+		assertEquals("m/44'/1'", nextPath("m/44'/0'"));
+		assertEquals("m/44'/2'", nextPath("m/44'/1'"));
+		assertEquals("m/44'/2147483647", nextPath("m/44'/2147483646"));
+		assertEquals("m/44'/2147483647'", nextPath("m/44'/2147483646'"));
+	}
+
+	private void assert_valid_path(String path) {
+		assertTrue(HDPath.validateBIP32Path(path));
 	}
 
 	private void assert_invalid_path(String path) {
+		assertFalse(HDPath.validateBIP32Path(path));
+		assert_throw_create_hdpath_from_string(path);
+	}
+
+	private void assert_throw_create_hdpath_from_string(String path) {
 		assertThatThrownBy(() -> DefaultHDPath.of(path))
 				.isInstanceOf(HDPathException.class);
+	}
+
+
+	private void assert_no_throw_create_hdpath_from_string(String path) {
+		try {
+			DefaultHDPath.of(path);
+		} catch (HDPathException e) {
+			fail("Expected no errors thrown");
+		}
+	}
+
+	private String nextPath(String path) {
+		try {
+			return BIP32Path.fromString(path)
+					.next().toString();
+		} catch (Exception e) {
+			return "";
+		}
 	}
 }

--- a/src/test/java/com/radixdlt/crypto/hdwallet/BIP32PathTests.java
+++ b/src/test/java/com/radixdlt/crypto/hdwallet/BIP32PathTests.java
@@ -81,6 +81,8 @@ public class BIP32PathTests {
 		assert_invalid_path("m/0/1//");
 
 		assert_invalid_path("m/44'/536' / 2' / 1/3");
+
+		assert_invalid_path("m/44H/0H");
 	}
 
 	@Test

--- a/src/test/java/com/radixdlt/crypto/hdwallet/BitcoinJHDKeyPairDerivationTest.java
+++ b/src/test/java/com/radixdlt/crypto/hdwallet/BitcoinJHDKeyPairDerivationTest.java
@@ -42,7 +42,12 @@ public class BitcoinJHDKeyPairDerivationTest {
 		String mnemonic = "equip will roof matter pink blind book anxiety banner elbow sun young";
 
 		HDKeyPairDerivation hdKeyPairDerivation = DefaultHDKeyPairDerivation.fromMnemonicString(mnemonic);
-		assertEquals("f85f7d078c1224603ad18f19b5bcf8b127af6a3558ebcc32325cf34dc5c8bfb9", ((BitcoinJHDKeyPairDerivation) hdKeyPairDerivation).rootPrivateKeyHex());
+
+		assertEquals(
+				"f85f7d078c1224603ad18f19b5bcf8b127af6a3558ebcc32325cf34dc5c8bfb9",
+				((BitcoinJHDKeyPairDerivation) hdKeyPairDerivation).rootPrivateKeyHex()
+		);
+
 		String bip32Path = "m/44'/536'/2'/1/3";
 		HDKeyPair childKey = hdKeyPairDerivation.deriveKeyAtPath(bip32Path);
 		assertEquals(bip32Path, childKey.path().toString());
@@ -57,9 +62,15 @@ public class BitcoinJHDKeyPairDerivationTest {
 
 	@Test
 	public void test_bip32_large_index() {
+		HDKeyPairDerivation hdKeyPairDerivation = DefaultHDKeyPairDerivation.fromSeed(
+				"fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"
+		);
 
-		HDKeyPairDerivation hdKeyPairDerivation = DefaultHDKeyPairDerivation.fromSeed("fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542");
-		assertEquals("4b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e", ((BitcoinJHDKeyPairDerivation) hdKeyPairDerivation).rootPrivateKeyHex());
+		assertEquals(
+				"4b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e",
+				((BitcoinJHDKeyPairDerivation) hdKeyPairDerivation).rootPrivateKeyHex()
+		);
+
 		String bip32Path = "m/0/2147483647'/1/2147483646'";
 		HDKeyPair childKey = hdKeyPairDerivation.deriveKeyAtPath(bip32Path);
 		assertEquals(bip32Path, childKey.path().toString());

--- a/src/test/java/com/radixdlt/crypto/hdwallet/BitcoinJHDKeyPairDerivationTest.java
+++ b/src/test/java/com/radixdlt/crypto/hdwallet/BitcoinJHDKeyPairDerivationTest.java
@@ -38,17 +38,40 @@ import static org.junit.Assert.assertNotNull;
 public class BitcoinJHDKeyPairDerivationTest {
 
 	@Test
-	public void test_hdwallet_bip32_five_components() {
+	public void test_bip32_five_components() {
 		String mnemonic = "equip will roof matter pink blind book anxiety banner elbow sun young";
 
 		HDKeyPairDerivation hdKeyPairDerivation = DefaultHDKeyPairDerivation.fromMnemonicString(mnemonic);
 		assertEquals("f85f7d078c1224603ad18f19b5bcf8b127af6a3558ebcc32325cf34dc5c8bfb9", ((BitcoinJHDKeyPairDerivation) hdKeyPairDerivation).rootPrivateKeyHex());
 		String bip32Path = "m/44'/536'/2'/1/3";
 		HDKeyPair childKey = hdKeyPairDerivation.deriveKeyAtPath(bip32Path);
-		assertEquals(bip32Path, childKey.path());
+		assertEquals(bip32Path, childKey.path().toString());
+		assertEquals(3L, childKey.index());
+		assertEquals(5, childKey.depth());
+		assertEquals(false, childKey.isHardened());
 		assertEquals("f423ae3097703022b86b87c15424367ce827d11676fae5c7fe768de52d9cce2e", childKey.privateKeyHex());
 		assertEquals("026d5e07cfde5df84b5ef884b629d28d15b0f6c66be229680699767cd57c618288", childKey.publicKeyHex());
+
+		assertEquals("m/44'/536'/2'/1/4", childKey.path().next().toString());
 	}
+
+	@Test
+	public void test_bip32_large_index() {
+
+		HDKeyPairDerivation hdKeyPairDerivation = DefaultHDKeyPairDerivation.fromSeed("fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542");
+		assertEquals("4b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e", ((BitcoinJHDKeyPairDerivation) hdKeyPairDerivation).rootPrivateKeyHex());
+		String bip32Path = "m/0/2147483647'/1/2147483646'";
+		HDKeyPair childKey = hdKeyPairDerivation.deriveKeyAtPath(bip32Path);
+		assertEquals(bip32Path, childKey.path().toString());
+		assertEquals(4294967294L, childKey.index());
+		assertEquals(4, childKey.depth());
+		assertEquals(true, childKey.isHardened());
+		assertEquals("f1c7c871a54a804afe328b4c83a1c33b8e5ff48f5087273f04efa83b247d6a2d", childKey.privateKeyHex());
+		assertEquals("02d2b36900396c9282fa14628566582f206a5dd0bcc8d5e892611806cafb0301f0", childKey.publicKeyHex());
+
+		assertEquals("m/0/2147483647'/1/2147483647'", childKey.path().next().toString());
+	}
+
 
 	@Test
 	public void bip32_test_vectors() {
@@ -67,6 +90,7 @@ public class BitcoinJHDKeyPairDerivationTest {
 			assertEquals(childVector.publicKeyHex(), childKey.publicKeyHex());
 			assertEquals(childVector.isHardened(), childKey.isHardened());
 			assertEquals(childVector.depth, childKey.depth());
+			assertEquals(childVector.index(), childKey.index());
 		}
 	}
 
@@ -137,6 +161,7 @@ public class BitcoinJHDKeyPairDerivationTest {
 			private boolean hardened;
 			private String pubKey;
 			private String privKey;
+			private long index;
 			int depth;
 
 			public String publicKeyHex() {
@@ -149,6 +174,10 @@ public class BitcoinJHDKeyPairDerivationTest {
 
 			public boolean isHardened() {
 				return hardened;
+			}
+
+			public long index() {
+				return index;
 			}
 		}
 


### PR DESCRIPTION
This PR introduced a new interface `HDPath` with concrete class implementing it, more specifically BIP32Path.

At a later point in time we can add BIP44 path specifically using Radix coin type (536' ?)

HDPath is wrapping underlying BitcoinJ utility/representation + own validation of a `String -> HDPath` (unfortunately BitcoinJ lacks a good one (only way of doing it is trying to catch NumberFormatException...)).

