### PR TITLE
Pre-compute and cache hashCode for ECPublicKey

### DIFF
--- a/src/main/java/com/radixdlt/utils/UInt256.java
+++ b/src/main/java/com/radixdlt/utils/UInt256.java
@@ -759,7 +759,7 @@ public final class UInt256 implements Comparable<UInt256> {
 
 	@Override
 	public int hashCode() {
-		return Objects.hashCode(this.high) * 31 + Objects.hashCode(this.low);
+		return this.high.hashCode() * 31 + this.low.hashCode();
 	}
 
 	@Override

--- a/src/test/java/com/radixdlt/crypto/ECKeyPairTest.java
+++ b/src/test/java/com/radixdlt/crypto/ECKeyPairTest.java
@@ -48,8 +48,8 @@ public class ECKeyPairTest {
 	@Test
 	public void equalsContract() {
 		EqualsVerifier.forClass(ECKeyPair.class)
-				.withIgnoredFields("publicKey") // public key is derived from used private key.
-				.verify();
+			.withIgnoredFields("publicKey") // public key is derived from used private key.
+			.verify();
 	}
 
 	@Test
@@ -108,13 +108,6 @@ public class ECKeyPairTest {
 	public void checkKeyPairEquals() {
 		EqualsVerifier.forClass(ECKeyPair.class)
 			.withIgnoredFields("publicKey") // Computed
-			.verify();
-	}
-
-	@Test
-	public void checkPublicKeyEquals() {
-		EqualsVerifier.forClass(ECPublicKey.class)
-			.withIgnoredFields("uid") // Computed and cached
 			.verify();
 	}
 

--- a/src/test/java/com/radixdlt/crypto/ECPublicKeyTest.java
+++ b/src/test/java/com/radixdlt/crypto/ECPublicKeyTest.java
@@ -5,9 +5,11 @@ import org.junit.Test;
 
 public class ECPublicKeyTest {
 	@Test
-	public void equalsContract() {
+	public void equalsContract() throws CryptoException {
+		ECPublicKey pk = ECPublicKey.fromBase64("AtuRjZPGw0b0BIYx46e0iKCaFU5EPnPx7/wLk6Vcursg");
 		EqualsVerifier.forClass(ECPublicKey.class)
-				.withIgnoredFields("uid") // hash of public key bytes.
-				.verify();
+			.withIgnoredFields("uid") // cached value
+			.withCachedHashCode("hashCode", "computeHashCode", pk)
+			.verify();
 	}
 }

--- a/src/test/java/com/radixdlt/utils/UInt256Test.java
+++ b/src/test/java/com/radixdlt/utils/UInt256Test.java
@@ -517,7 +517,9 @@ public class UInt256Test {
 
 	@Test
 	public void equalsContract() {
-		EqualsVerifier.forClass(UInt256.class).verify();
+		EqualsVerifier.forClass(UInt256.class)
+			.withNonnullFields("high", "low")
+			.verify();
 	}
 
 	/**


### PR DESCRIPTION
Improved potential performance of UInt256 hashCode as well, although
benefits are not as clear as ECPublicKey.

Removed duplicate ECPublicKey hashCode/equals test from ECKeyPair.